### PR TITLE
Add "libavutil/display.h" to files to parse for rotation information

### DIFF
--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Program.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Program.cs
@@ -101,6 +101,7 @@ internal class Program
         yield return p.Parse("libavutil/audio_fifo.h");
         yield return p.Parse("libavutil/channel_layout.h");
         yield return p.Parse("libavutil/cpu.h");
+        yield return p.Parse("libavutil/display.h");
         yield return p.Parse("libavutil/file.h");
         yield return p.Parse("libavutil/frame.h");
         yield return p.Parse("libavutil/opt.h");


### PR DESCRIPTION
With the recent upgrade from FFmpeg 4.3.6 to 6.1.1, parsing rotation information from the file metadata is no longer available. We now use the rotation matrix provided with the stream and converting that matrix to a rotation in angle is made a lot easier thanks to some items from `libavutil/display.h`.